### PR TITLE
Improve hook performance

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "haystack-react",
-	"version": "3.0.2",
+	"version": "3.0.3-beta.1",
 	"description": "Project Haystack utilities for building React applications",
 	"main": "dist/index",
 	"scripts": {

--- a/src/watch.ts
+++ b/src/watch.ts
@@ -120,7 +120,8 @@ export function useWatch({
 						return watch
 					}
 
-					watch.pollRate = pollRate || DEFAULT_POLL_RATE_SECS
+					watch.pollRate =
+						pollRate > 0 ? pollRate : DEFAULT_POLL_RATE_SECS
 
 					watch.changed({
 						callback: forceUpdate,


### PR DESCRIPTION
@riccardolederj2 found some performance issues regarding haystack-react. The hooks use `useState` too much in their design that causes excessive rerenders. 

These changes modify the hooks so the state change is more deliberate. `useRef` is used to hold extra information used in the hook that doesn't cause any state changes.