### PR TITLE
Fixes default client context error when lib used in SSR mode

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -132,7 +132,7 @@ export function useGrid({
  */
 export const ClientContext = createContext<Client>(
 	new Client({
-		base: new URL(window.location.href),
+		base: new URL(globalThis?.window?.location.href || 'http://localhost'),
 	})
 )
 ClientContext.displayName = 'Client'

--- a/src/client.ts
+++ b/src/client.ts
@@ -132,7 +132,7 @@ export function useGrid({
  */
 export const ClientContext = createContext<Client>(
 	new Client({
-		base: new URL(globalThis?.window?.location.href || 'http://localhost'),
+		base: new URL(globalThis?.location.href || 'http://localhost'),
 	})
 )
 ClientContext.displayName = 'Client'


### PR DESCRIPTION
This happens when the client context is used in SSR apps like Next JS. When the context is created, it tries to make a default value which accesses the undefined window object. The fix remedies this issue, and creates a fake context, ready to be overridden by dev (which one has to) using the context in the app.